### PR TITLE
Añadido tiempo de horneado. Cierra #1

### DIFF
--- a/receta.txt
+++ b/receta.txt
@@ -1,3 +1,3 @@
 Tarta de moras
 Ingredientes: moras, harina, mantequilla y azúcar blanco o moreno.
-Preparación: mezclar y hornear a 180 grados
+Preparación: mezclar y hornear a 180 grados durante 45 minutos.


### PR DESCRIPTION
Añadido el tiempo de horneado de 45 minutos en la receta de la tarta de moras. Resuelve el Issue #1 reportado por TikasWorld.